### PR TITLE
fix: unlock the core library dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=8.0.0",
         "ext-json": "*",
         "nyholm/psr7": "^1.8",
-        "oat-sa/lib-lti1p3-core": "7.2.2",
+        "oat-sa/lib-lti1p3-core": "^7.0",
         "psr/http-message": "^1.1 || ^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR fixes dependency mishap introduced in https://github.com/oat-sa/lib-lti1p3-nrps/pull/37